### PR TITLE
perf(typewriter): double BlogGPT reveal speed

### DIFF
--- a/assets/js/typewriter.js
+++ b/assets/js/typewriter.js
@@ -26,7 +26,7 @@ permalink: /assets/js/typewriter.js
    *   - Skip restores all innerHTML instantly
    */
 
-  var CHAR_DELAY = 80;
+  var CHAR_DELAY = 40;  /* ms per character (~25 chars/sec) */
   var SKIP_DELAY  = 3000;
   var FRAME_BUDGET_MS = 12;  /* Leave 4ms headroom for 60fps (16.67ms/frame) */
   var DEBUG_PERF = false;


### PR DESCRIPTION
Halve CHAR_DELAY from 80ms to 40ms per character (12.5 -> 25 chars/sec). The reveal loop types at most one character per animation frame, so the effective floor is ~16.67ms; 40ms stays well above it and yields a true 2x.